### PR TITLE
Openwrt 22.03

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PKG_RELEASE=1
 PKG_LICENSE:=GPLv2
 PKG_LICENSE_FILES:=
 
-PKG_SOURCE_URL:=https://github.com/erintera/88x2bu-20210702
+PKG_SOURCE_URL:=https://github.com/morrownr/88x2bu-20210702
 
 PKG_MIRROR_HASH:=skip
 PKG_SOURCE_PROTO:=git

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PKG_RELEASE=1
 PKG_LICENSE:=GPLv2
 PKG_LICENSE_FILES:=
 
-PKG_SOURCE_URL:=https://github.com/morrownr/88x2bu-20210702
+PKG_SOURCE_URL:=https://github.com/erintera/88x2bu-20210702
 
 PKG_MIRROR_HASH:=skip
 PKG_SOURCE_PROTO:=git


### PR DESCRIPTION
  CC [M]  /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/core/crypto/aes-siv.o
  CC [M]  /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/core/crypto/aes-ctr.o
  CC [M]  /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/core/crypto/sha256-internal.o
  CC [M]  /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/core/crypto/sha256.o
  CC [M]  /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/core/crypto/sha256-prf.o
  CC [M]  /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/core/crypto/rtw_crypto_wrap.o
  CC [M]  /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/core/rtw_swcrypto.o
  CC [M]  /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/os_dep/osdep_service.o
  CC [M]  /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/os_dep/linux/os_intfs.o
In file included from <command-line>:
/home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/os_dep/linux/os_intfs.c: In function 'rtw_os_ndev_register':
/home/openwrt-5-x86/staging_dir/target-x86_64_musl/usr/include/mac80211-backport/backport/backport.h:10:31: error: too many arguments to function 'backport_netif_napi_add'
   10 | #define LINUX_BACKPORT(__sym) backport_ ##__sym
      |                               ^~~~~~~~~
/home/openwrt-5-x86/staging_dir/target-x86_64_musl/usr/include/mac80211-backport/linux/netdevice.h:33:24: note: in expansion of macro 'LINUX_BACKPORT'
   33 | #define netif_napi_add LINUX_BACKPORT(netif_napi_add)
      |                        ^~~~~~~~~~~~~~
/home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/os_dep/linux/os_intfs.c:2157:9: note: in expansion of macro 'netif_napi_add'
 2157 |         netif_napi_add(ndev, &adapter->napi, rtw_recv_napi_poll, RTL_NAPI_WEIGHT);
      |         ^~~~~~~~~~~~~~
In file included from /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/include/osdep_service_linux.h:31,
                 from /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/include/osdep_service.h:54,
                 from /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/include/drv_types.h:27,
                 from /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/os_dep/linux/os_intfs.c:17:
/home/openwrt-5-x86/staging_dir/target-x86_64_musl/usr/include/mac80211-backport/linux/netdevice.h:27:20: note: declared here
   27 | static inline void backport_netif_napi_add(struct net_device *dev,
      |                    ^~~~~~~~~~~~~~~~~~~~~~~
make[5]: *** [scripts/Makefile.build:289: /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/os_dep/linux/os_intfs.o] Error 1
make[4]: *** [Makefile:1904: /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754] Error 2
make[4]: Leaving directory '/home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/linux-5.15.91'
make[3]: *** [Makefile:57: /home/openwrt-5-x86/build_dir/target-x86_64_musl/linux-x86_64/rtl88x2bu-2022-05-23-6c2ca754/.built] Error 2
make[3]: Leaving directory '/home/openwrt-5-x86/package/kernel/rtl88x2bu'
time: package/kernel/rtl88x2bu/compile#190.99#36.91#229.60
    ERROR: package/kernel/rtl88x2bu failed to build.
make[2]: *** [package/Makefile:116: package/kernel/rtl88x2bu/compile] Error 1
make[2]: Leaving directory '/home/openwrt-5-x86'
make[1]: *** [package/Makefile:110: /home/openwrt-5-x86/staging_dir/target-x86_64_musl/stamp/.package_compile] Error 2
make[1]: Leaving directory '/home/openwrt-5-x86'
make: *** [/home/openwrt-5-x86/include/toplevel.mk:231：world] 错误 2
